### PR TITLE
The server should depend on its parent proccess

### DIFF
--- a/lib/wrap_server.js
+++ b/lib/wrap_server.js
@@ -105,7 +105,7 @@ class WrapServer extends EventEmitter {
           'nogui'
         ], {
           stdio: 'pipe',
-          detached: true,
+          detached: false,
           cwd: this.MC_SERVER_PATH
         })
         this.mcServer.stdin.setEncoding('utf8')


### PR DESCRIPTION
Otherwise if the parent dies, the server stays running in the background with the only way to stop it via the task manager

Probably closes https://github.com/PrismarineJS/mineflayer/issues/1397