### PR TITLE
allow explicitly picking a java executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ initialize a wrapper with jar `MC_SERVER_JAR`, store mc server file at `MC_SERVE
 * maxMem : the maximum memory allocated to the minecraft server, default to 512
 * doneRegex : the regex to check for the server message announcing the server has started, default to `new RegExp(/\[Server thread\/INFO\]: Done/)`
 * noOverride : don't override config files
+* javaPath : specify path to a java executable to use, by default it's just `java`
 
 #### WrapServer.startServer(propOverrides, done)
 

--- a/lib/wrap_server.js
+++ b/lib/wrap_server.js
@@ -50,7 +50,8 @@ class WrapServer extends EventEmitter {
       minMem: (OPTIONS && OPTIONS.minMem) ? OPTIONS.minMem : '1024',
       maxMem: (OPTIONS && OPTIONS.maxMem) ? OPTIONS.maxMem : '1024',
       doneRegex: (OPTIONS && OPTIONS.doneRegex) ? OPTIONS.doneRegex : /\[.+\]: Done/,
-      noOverride: OPTIONS && OPTIONS.noOverride
+      noOverride: OPTIONS && OPTIONS.noOverride,
+      javaPath: OPTIONS && OPTIONS.javaPath
     }
   }
 
@@ -97,7 +98,7 @@ class WrapServer extends EventEmitter {
         })
       })
       .then(() => new Promise((resolve, reject) => {
-        this.mcServer = spawn('java', [
+        this.mcServer = spawn(this.OPTIONS.javaPath ?? 'java', [
           '-jar',
           '-Xms' + this.OPTIONS.minMem + 'M',
           '-Xmx' + this.OPTIONS.maxMem + 'M',


### PR DESCRIPTION
useful if you have two java installations