### PR TITLE
Don't use broken native transport

### DIFF
--- a/lib/wrap_server.js
+++ b/lib/wrap_server.js
@@ -38,7 +38,8 @@ const defaultServerProps = {
   'generate-structures': 'true',
   'view-distance': '10',
   'spawn-protection': '16',
-  motd: 'A Minecraft Server'
+  motd: 'A Minecraft Server',
+  'use-native-transport': 'false'
 }
 
 class WrapServer extends EventEmitter {


### PR DESCRIPTION
This is a performance option that we don't care about, it's also broken on some combinations of JVM and Minecraft server. Let's ditch it.