### PR TITLE
Add a startServer wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,10 @@ extract the natives files and return a promise to the path of the dir
 get all the libraries, save them and return a promise of an array of the paths
 
 
+#### startServer(version, port = 25565, serverProperties): Promise
+
+Async wrapper for starting a server
+
 ## Testing
 
 The MC_SERVER_JAR environment variable must be defined and point the .jar location before calling npm test.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ npm install -g minecraft-wrap
 ```
 downloadMinecraft 1.8.8 1.8.8.jar server
 runMinecraft [<minecraft dir>] [<version>] [<username>] [<password>] [<stop>]
+startServer <version> [port] [online] [path]
 ```
 
 See [examples](examples)

--- a/examples/startServer.js
+++ b/examples/startServer.js
@@ -3,22 +3,13 @@ const { startServer } = require('../')
 
 const [,, version, port, online, path] = process.argv
 
-console.log(process.argv)
-
 if (!version) {
   console.error('startServer <version> [port] [online] [path]')
   process.exit(1)
 }
 
-const opt = {
-  version,
-  port: parseInt(port, 10) || 25565,
-  online,
-  path
-}
+const opt = { 'online-mode': Boolean(online), path: path ? path : undefined }
 
-console.log(opt)
-
-startServer(opt.version, port, { 'online-mode': Boolean(opt.online), path: opt.path ? opt.path : undefined }).then(p => {
+startServer(version, port || 25565, opt).then(p => {
   process.stdin.pipe(p.mcServer.stdin)
 })

--- a/examples/startServer.js
+++ b/examples/startServer.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const { startServer } = require('../')
+
+const [,, version, port, online, path] = process.argv
+
+console.log(process.argv)
+
+if (!version) {
+  console.error('startServer <version> [port] [online] [path]')
+  process.exit(1)
+}
+
+const opt = {
+  version,
+  port: parseInt(port, 10) || 25565,
+  online,
+  path
+}
+
+console.log(opt)
+
+startServer(opt.version, port, { 'online-mode': Boolean(opt.online), path: opt.path ? opt.path : undefined }).then(p => {
+  process.stdin.pipe(p.mcServer.stdin)
+})

--- a/examples/startServer.js
+++ b/examples/startServer.js
@@ -8,7 +8,7 @@ if (!version) {
   process.exit(1)
 }
 
-const opt = { 'online-mode': Boolean(online), path: path ? path : undefined }
+const opt = { 'online-mode': Boolean(online), path: path || undefined }
 
 startServer(version, port || 25565, opt).then(p => {
   process.stdin.pipe(p.mcServer.stdin)

--- a/index.js
+++ b/index.js
@@ -5,5 +5,7 @@ module.exports = {
   download: require('./lib/download').downloadServer,
   downloadServer: require('./lib/download').downloadServer,
   downloadClient: require('./lib/download').downloadClient,
-  LauncherDownload: require('./lib/launcher_download')
+  LauncherDownload: require('./lib/launcher_download'),
+  startServer: require('./lib/startServer').startServer,
+  collectPackets: require('./lib/startServer').collectPackets
 }

--- a/lib/startServer.js
+++ b/lib/startServer.js
@@ -5,15 +5,15 @@ const path = require('path')
 const debug = require('debug')('minecraft-wrap')
 
 async function startServer (version, port = 25565, serverProperties = {}) {
-  const MC_SERVER_PATH = path.join(__dirname, `../versions/server_${version}`)
-  const MC_SERVER_JAR = path.join(__dirname, `../versions/server_${version}.jar`)
+  const MC_SERVER_PATH = serverProperties.path || path.join(__dirname, `../versions/server_${version}`)
+  const MC_SERVER_JAR = serverProperties.path || path.join(__dirname, `../versions/server_${version}.jar`)
 
   await downloadServer(version, MC_SERVER_JAR)
 
   const vServer = new WrapServer(MC_SERVER_JAR, MC_SERVER_PATH)
 
   vServer.on('line', function (line) {
-    debug(line)
+    console.log(line)
   })
 
   const settings = {

--- a/lib/startServer.js
+++ b/lib/startServer.js
@@ -4,7 +4,7 @@ const downloadServer = promisify(require('./download').downloadServer)
 const path = require('path')
 const debug = require('debug')('minecraft-wrap')
 
-async function startServer (version, port = 25569, serverProperties = {}) {
+async function startServer (version, port = 25565, serverProperties = {}) {
   const MC_SERVER_PATH = path.join(__dirname, `../versions/server_${version}`)
   const MC_SERVER_JAR = path.join(__dirname, `../versions/server_${version}.jar`)
 

--- a/lib/startServer.js
+++ b/lib/startServer.js
@@ -1,0 +1,80 @@
+const promisify = require('util').promisify
+const WrapServer = require('./wrap_server')
+const downloadServer = promisify(require('./download').downloadServer)
+const path = require('path')
+const debug = require('debug')('minecraft-wrap')
+
+async function startServer (version, port = 25569, serverProperties = {}) {
+  const MC_SERVER_PATH = path.join(__dirname, `../versions/server_${version}`)
+  const MC_SERVER_JAR = path.join(__dirname, `../versions/server_${version}.jar`)
+
+  await downloadServer(version, MC_SERVER_JAR)
+
+  const vServer = new WrapServer(MC_SERVER_JAR, MC_SERVER_PATH)
+
+  vServer.on('line', function (line) {
+    debug(line)
+  })
+
+  const settings = {
+    'online-mode': 'false',
+    'server-port': port,
+    'view-distance': 2,
+    'level-type': 'flat',
+    ...serverProperties
+  }
+
+  await new Promise(resolve => vServer.startServer(settings, resolve))
+
+  vServer.stop = async () => new Promise((resolve, reject) => vServer.stopServer(reject, resolve))
+
+  return vServer
+}
+
+async function collectPackets (nmp, version, names = [], cb, { timeout = 9000, port = 25569 } = {}) {
+  const collected = []
+  console.log('🔻 Downloading server', version)
+  const server = await startServer(version, port)
+  console.log('Started server')
+
+  const client = nmp.createClient({
+    version: version,
+    host: 'localhost',
+    port,
+    username: 'test' + (Date.now() & 0xffff)
+  })
+
+  let clientConnected = false
+
+  client.on('connect', () => {
+    console.log('Client connected')
+    clientConnected = true
+  })
+
+  for (const name of names) {
+    client.on(name, (packet) => {
+      cb(name, packet)
+      collected.push(packet)
+    })
+  }
+
+  client.on('packet', (data, { name }) => debug('[client] -> ', name))
+
+  let didQuit = false
+  function finish () {
+    if (didQuit) return
+    didQuit = true
+    console.log('Stopping server')
+    server.stop()
+    client.end()
+    if (!clientConnected) {
+      throw new Error('Client never connected')
+    }
+  }
+
+  setTimeout(finish, timeout)
+  server.finish = finish
+  return server
+}
+
+module.exports = { startServer, collectPackets }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "yggdrasil": "^1.1.1"
   },
   "devDependencies": {
-    "mocha": "^9.0.0",
+    "mocha": "^9.2.0",
+    "minecraft-protocol": "^1.30.0",
+    "minecraft-wrap": "file:.",
     "standard": "^16.0.1"
   },
   "bin": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "standard",
     "fix": "standard --fix",
     "downloadMinecraft": "./examples/exampleDownload.js",
-    "runMinecraft": "./examples/exampleWrapClient.js"
+    "runMinecraft": "./examples/exampleWrapClient.js",
+    "startServer": "node ./examples/startServer.js"
   },
   "repository": {
     "type": "git",
@@ -48,6 +49,7 @@
   },
   "bin": {
     "downloadMinecraft": "./examples/exampleDownload.js",
-    "runMinecraft": "./examples/exampleWrapClient.js"
+    "runMinecraft": "./examples/exampleWrapClient.js",
+    "startServer": "./examples/startServer.js"
   }
 }

--- a/test/collectPackets.js
+++ b/test/collectPackets.js
@@ -4,9 +4,9 @@ const nmp = require('minecraft-protocol')
 
 describe('it can collect packets from server', function () {
   this.timeout(10 * 60 * 1000) // 1 min
-  it('works on 1.18', (done) => {
+  it('works on 1.13', (done) => {
     let collector
-    collectPackets(nmp, '1.18', ['login'], (name, params) => {
+    collectPackets(nmp, '1.13', ['login'], (name, params) => {
       if (name === 'login') {
         console.log('✅ Got login')
         collector.finish()

--- a/test/collectPackets.js
+++ b/test/collectPackets.js
@@ -1,0 +1,17 @@
+/* eslint-env mocha */
+const { collectPackets } = require('minecraft-wrap')
+const nmp = require('minecraft-protocol')
+
+describe('it can collect packets from server', function () {
+  this.timeout(10 * 60 * 1000) // 1 min
+  it('works on 1.18', (done) => {
+    let collector
+    collectPackets(nmp, '1.18', ['login'], (name, params) => {
+      if (name === 'login') {
+        console.log('✅ Got login')
+        collector.finish()
+        done()
+      }
+    }).catch(console.error).then(c => { collector = c })
+  })
+})


### PR DESCRIPTION
Taken from prismarine-registry, left in the collectBlock function as it might be useful for other places. Otherwise this can be removed maybe to another package if needed