### PR TITLE
kill process when shutdown takes to long

### DIFF
--- a/lib/wrap_server.js
+++ b/lib/wrap_server.js
@@ -64,8 +64,13 @@ class WrapServer extends EventEmitter {
       return
     }
     this.mcServer.stdin.write('stop\n')
+    const timeoutHandle = setTimeout(() => {
+      console.warn('Server shutdown took to long. Killing process.')
+      this.mcServer.kill()
+    }, 10000)
     this.mcServer.on('close', () => {
       this.mcServer = null
+      clearTimeout(timeoutHandle)
       done()
     })
   }


### PR DESCRIPTION
My 1.8 server is not shutting down after stop is send to the server. This should fix that.