### PR TITLE
fix(download): Fix etag not md5 on all downloads

### DIFF
--- a/lib/etag_download.js
+++ b/lib/etag_download.js
@@ -1,7 +1,7 @@
 const https = require('https')
 const fs = require('fs')
 const md5File = require('md5-file')
-const mkdirp = require('mkdirp')
+const { mkdir } = require('fs').promises
 
 module.exports = download
 
@@ -13,48 +13,61 @@ function download (url, filename, done) {
     return
   }
 
+  // Get etag => try to checksum file already there against etag => miss => do GET. If you get a cache hit, noop.
   const p = new Promise((resolve, reject) => {
     https.get(url, function (response) {
       if (response.statusCode === 200) {
-        checkSum(filename, response.headers.etag, function (err, alreadyThere) {
-          if (err) {
-            return reject(err)
-          }
-          if (!alreadyThere) {
-            const parts = filename.split('/')
-            parts.pop()
-            const dirPath = parts.join('/')
-            return mkdirp(dirPath, (err) => {
-              if (err) {
-                return reject(err)
+        const etagIsChecksumable = response.headers.server === 'AmazonS3' // s3 puts md5 in etag, others hosts don't
+        checkSum(filename, response.headers.etag).then(alreadyDownloaded => {
+          if (!alreadyDownloaded) {
+            doDownload(filename, response, etagIsChecksumable, url).then((isCorrect) => {
+              if (!isCorrect) {
+                reject(new Error(`download failed : wrong or partial file downloaded ${url} ${filename}`))
+              } else {
+                resolve(filename)
               }
-              const file = fs.createWriteStream(filename)
-              response.pipe(file)
-                .on('close', function () {
-                  checkSum(filename, response.headers.etag, function (err, correct) {
-                    if (err) {
-                      return reject(err)
-                    }
-                    if (!correct) {
-                      reject(new Error('download failed : wrong or partial file downloaded ' + url + ' ' + filename))
-                    } else {
-                      resolve(filename)
-                    }
-                  })
-                })
             })
-          } else { resolve(filename) }
+          } else {
+            resolve(filename)
+          }
         })
-      } else { reject(new Error('download failed : server responds with status ' + response.statusCode + ' ' + url + ' ' + filename)) }
+      } else {
+        reject(new Error('download failed : server responds with status ' + response.statusCode + ' ' + url + ' ' + filename))
+      }
     })
   })
   pathsPromises[filename] = p
   p.then((r) => done(null, r)).catch(err => done(err))
 }
 
-function checkSum (filename, etag, done) {
-  md5File(filename, function (err, sum) {
-    const expectedSum = etag.substr(1, etag.length - 2)
-    done(null, !(err || expectedSum !== sum))
+// if shouldChecksum, we will use the etag
+async function doDownload (filename, response, shouldChecksum, url) {
+  const parts = filename.split('/')
+  parts.pop()
+  const dirPath = parts.join('/')
+  await mkdir(dirPath, { recursive: true })
+  const file = fs.createWriteStream(filename)
+  return await new Promise((resolve, reject) => {
+    response.pipe(file).on('close', () => {
+      if (shouldChecksum) {
+        checkSum(filename, response.headers.etag).then((isCorrectFile) => {
+          if (isCorrectFile) {
+            resolve(filename)
+          } else {
+            reject(new Error('download failed : wrong or partial file downloaded ' + url + ' ' + filename))
+          }
+        })
+      }
+      resolve(filename)
+    })
+  })
+}
+
+async function checkSum (filename, etag) {
+  return new Promise((resolve, reject) => {
+    md5File(filename, function (err, sum) {
+      const expectedSum = etag.substr(1, etag.length - 2)
+      resolve(!err && expectedSum === sum)
+    })
   })
 }

--- a/lib/wrap_client.js
+++ b/lib/wrap_client.js
@@ -38,7 +38,7 @@ class WrapClient extends EventEmitter {
       const updateProfile = (name) => {
         if (!auths.profiles) { auths.profiles = {} }
         auths.profiles[name] = {
-          name: name,
+          name,
           lastVersionId: this.version,
           allowedReleaseTypes: [
             'release',


### PR DESCRIPTION
As of 1.19, some downloads are hosted on azure, which doesn't put md5
in the etag of the download url.